### PR TITLE
feat: Upload Card from Device File (HTML/Image)

### DIFF
--- a/src/static/css/dashboard.css
+++ b/src/static/css/dashboard.css
@@ -357,6 +357,58 @@ body {
     .tv-monitors { grid-template-columns: 1fr; }
 }
 
+/* Upload Zone */
+.upload-zone {
+    border: 2px dashed var(--border);
+    border-radius: 6px;
+    padding: 24px;
+    text-align: center;
+    transition: border-color 0.2s, background 0.2s;
+    cursor: pointer;
+}
+.upload-zone:hover {
+    border-color: var(--text-muted);
+}
+.upload-zone.drag-active {
+    border-color: var(--accent);
+    background: rgba(255,107,53,0.06);
+}
+.upload-zone.upload-done {
+    border-color: var(--success);
+    border-style: solid;
+    background: rgba(34,197,94,0.06);
+}
+.upload-prompt {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    color: var(--text-muted);
+}
+.upload-prompt svg { opacity: 0.5; }
+.upload-prompt span { font-size: 14px; }
+.upload-hint {
+    font-size: 11px;
+    color: var(--text-muted);
+    opacity: 0.7;
+    margin-top: 2px;
+}
+.upload-success {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    color: var(--success);
+    font-size: 14px;
+    font-weight: 500;
+}
+.upload-success span {
+    max-width: 260px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 /* Canva Import */
 .canva-import-section {
     margin-bottom: 14px;

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -129,6 +129,33 @@
                         <option value="mod">Mod (Default for Modboard)</option>
                     </select>
                 </div>
+                <!-- Upload Card File -->
+                <div class="form-row">
+                    <label>Upload Card File</label>
+                    <div class="upload-zone" id="uploadZone">
+                        <input type="file" id="fileInput" accept=".html,.htm,.png,.jpg,.jpeg" hidden>
+                        <div class="upload-prompt" id="uploadPrompt">
+                            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+                                <polyline points="17 8 12 3 7 8"/>
+                                <line x1="12" y1="3" x2="12" y2="15"/>
+                            </svg>
+                            <span>Drag & drop an HTML or image file here</span>
+                            <button type="button" class="btn btn-secondary btn-sm" id="browseBtn">Browse Files</button>
+                            <small class="upload-hint">.html, .htm, .png, .jpg, .jpeg — Max 5 MB</small>
+                        </div>
+                        <div class="upload-success hidden" id="uploadSuccess">
+                            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--success)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/>
+                                <polyline points="22 4 12 14.01 9 11.01"/>
+                            </svg>
+                            <span id="uploadFileName"></span>
+                            <button type="button" class="btn btn-secondary btn-sm" id="clearUploadBtn">Clear</button>
+                        </div>
+                    </div>
+                    <div id="uploadError" class="message error hidden"></div>
+                </div>
+
                 <!-- Canva Import -->
                 <div class="canva-import-section">
                     <h3 class="section-label">Import from Canva</h3>


### PR DESCRIPTION
## Summary
- Adds drag-and-drop upload zone to the Push Schedule form for HTML files and images (PNG/JPG)
- HTML files populate the card textarea with automatic `<title>` extraction for workout title
- Images are base64-encoded and wrapped in a 1920x1080 HTML shell for TV display
- Includes file type validation and 5MB size limit with error feedback

## Test plan
- [ ] Drag & drop an `.html` file → HTML populates the form, preview works
- [ ] Drag & drop a `.png` or `.jpg` → image wrapped in 1920x1080 HTML, preview shows correctly
- [ ] Click "Browse Files" to open file picker as alternative to drag/drop
- [ ] Invalid file types show clear error message
- [ ] Files > 5MB show size error
- [ ] After file load, "Push to Schedule" flow works as normal
- [ ] Upload zone shows filename + checkmark after successful load
- [ ] "Clear" button resets upload state

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)